### PR TITLE
Fix header color to use --dark variable for mobile responsive theming

### DIFF
--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -19,6 +19,10 @@ PageTitle.css = `
   margin: 0;
   font-family: var(--titleFont);
 }
+
+.page-title a {
+  color: var(--dark);
+}
 `
 
 export default (() => PageTitle) satisfies QuartzComponentConstructor


### PR DESCRIPTION
The PageTitle link was using the default link color (--secondary) instead
of the proper header color (--dark), causing it not to respond correctly
to theme changes on mobile. Added explicit color styling to ensure the
header text uses --dark in both light and dark modes on all screen sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the page title link color for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->