### PR TITLE
Reduce page color saturation and make texture overlay more subtle

### DIFF
--- a/quartz/components/scripts/pageColor.inline.ts
+++ b/quartz/components/scripts/pageColor.inline.ts
@@ -12,9 +12,9 @@ const applyPageColor = () => {
   const root = document.documentElement
   const isDark = root.getAttribute("saved-theme") === "dark"
 
-  // Noticeable tint per page
-  const lightBg = `hsl(${hue}, 18%, 97%)`
-  const darkBg = `hsl(${hue}, 15%, 10%)`
+  // Very subtle tint per page - low saturation for cleaner backgrounds
+  const lightBg = `hsl(${hue}, 3%, 98%)`
+  const darkBg = `hsl(${hue}, 3%, 8%)`
 
   root.style.setProperty("--light", isDark ? darkBg : lightBg)
 }

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,10 +1,22 @@
 @use "./base.scss";
 
-// 1. Subtle texture/grain on background
+// 1. Very subtle texture/grain on background
 body {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
-  background-blend-mode: overlay;
-  background-size: 200px;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+    background-size: 200px;
+    opacity: 0.03;
+    pointer-events: none;
+    z-index: -1;
+  }
 }
 
 // 2. Distinctive link styling (underline instead of highlight box)


### PR DESCRIPTION
- Reduce page tint saturation from 18%/15% to 3%/3% for cleaner backgrounds
- Adjust lightness values to 98%/8% for stronger light/dark contrast
- Convert texture overlay to pseudo-element with 3% opacity for subtlety
- Fixes "speckled gray" appearance in both light and dark modes on mobile

The previous high saturation (18%) was making backgrounds appear more gray/tinted rather than clean white/black. The new 3% saturation maintains a subtle per-page color hint while ensuring proper theme color visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual design with more subtle page color tints and reduced background texture opacity for a cleaner, more refined interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->