### PR TITLE
Enable Giscus comments on all content pages

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -5,7 +5,23 @@ import * as Component from "./quartz/components"
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
   header: [],
-  afterBody: [Component.PageColor()],
+  afterBody: [
+    Component.Comments({
+      provider: "giscus",
+      options: {
+        repo: "RanbirSinghLive/obsidianvault",
+        repoId: "R_kgDOOcSKoA",
+        category: "Announcements",
+        categoryId: "DIC_kwDOOcSKoM4C1DNe",
+        mapping: "pathname",
+        strict: false,
+        reactionsEnabled: true,
+        inputPosition: "bottom",
+        lang: "en",
+      },
+    }),
+    Component.PageColor(),
+  ],
   footer: Component.Footer({
     links: {
       "Twitter/X": "https://x.com/ranbirsinghlive",


### PR DESCRIPTION
Added Comments component to afterBody section with GitHub Discussions integration. Comments will appear at the bottom of all pages (unless disabled via frontmatter).

Configuration:
- Repository: RanbirSinghLive/obsidianvault
- Category: Announcements
- Mapping: pathname (each URL gets its own thread)
- Reactions enabled with input at bottom
- Automatic theme switching support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comments section to pages, enabling users to leave feedback and engage in discussions directly on page content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->