### PR TITLE
Add previous/next navigation links for Cards folder

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -6,6 +6,10 @@ export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
   header: [],
   afterBody: [
+    Component.NextPrevious({
+      hideWhenEmpty: true,
+      includeFolders: ["Cards"],
+    }),
     Component.Comments({
       provider: "giscus",
       options: {

--- a/quartz/components/NextPrevious.tsx
+++ b/quartz/components/NextPrevious.tsx
@@ -1,0 +1,110 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import style from "./styles/nextprevious.scss"
+import { resolveRelative, simplifySlug } from "../util/path"
+import { classNames } from "../util/lang"
+import { trieFromAllFiles } from "../util/ctx"
+
+interface NextPreviousOptions {
+  /**
+   * Hide navigation when no siblings exist
+   */
+  hideWhenEmpty: boolean
+  /**
+   * Folders where navigation should appear (empty array means all folders)
+   */
+  includeFolders: string[]
+}
+
+const defaultOptions: NextPreviousOptions = {
+  hideWhenEmpty: true,
+  includeFolders: ["Cards"],
+}
+
+export default ((opts?: Partial<NextPreviousOptions>) => {
+  const options: NextPreviousOptions = { ...defaultOptions, ...opts }
+
+  const NextPrevious: QuartzComponent = ({
+    fileData,
+    allFiles,
+    displayClass,
+    ctx,
+  }: QuartzComponentProps) => {
+    const trie = (ctx.trie ??= trieFromAllFiles(allFiles))
+    const slugParts = fileData.slug!.split("/")
+
+    // Check if the current page is in one of the included folders
+    if (options.includeFolders.length > 0) {
+      const isInIncludedFolder = options.includeFolders.some((folder) =>
+        fileData.slug!.startsWith(`${folder}/`),
+      )
+      if (!isInIncludedFolder) {
+        return null
+      }
+    }
+
+    // Get parent folder node
+    const parentPath = slugParts.slice(0, -1)
+    const parentNode = trie.findNode(parentPath)
+
+    if (!parentNode) {
+      return null
+    }
+
+    // Get all non-folder siblings (actual pages)
+    const siblings = parentNode.children
+      .filter((child) => !child.isFolder && child.data)
+      .sort((a, b) => {
+        const aTitle = a.displayName.toLowerCase()
+        const bTitle = b.displayName.toLowerCase()
+        return aTitle.localeCompare(bTitle)
+      })
+
+    // Find current page index
+    const currentIndex = siblings.findIndex((child) => child.slug === fileData.slug)
+
+    if (currentIndex === -1 || siblings.length <= 1) {
+      return options.hideWhenEmpty ? null : <div />
+    }
+
+    const previousPage = currentIndex > 0 ? siblings[currentIndex - 1] : null
+    const nextPage = currentIndex < siblings.length - 1 ? siblings[currentIndex + 1] : null
+
+    if (!previousPage && !nextPage) {
+      return options.hideWhenEmpty ? null : <div />
+    }
+
+    return (
+      <nav class={classNames(displayClass, "nextprevious-container")} aria-label="page navigation">
+        <div class="nextprevious-wrapper">
+          {previousPage ? (
+            <a href={resolveRelative(fileData.slug!, previousPage.slug)} class="previous">
+              <span class="arrow">←</span>
+              <div class="link-content">
+                <span class="label">Previous</span>
+                <span class="page-title">{previousPage.displayName}</span>
+              </div>
+            </a>
+          ) : (
+            <div class="spacer" />
+          )}
+
+          {nextPage ? (
+            <a href={resolveRelative(fileData.slug!, nextPage.slug)} class="next">
+              <div class="link-content">
+                <span class="label">Next</span>
+                <span class="page-title">{nextPage.displayName}</span>
+              </div>
+              <span class="arrow">→</span>
+            </a>
+          ) : (
+            <div class="spacer" />
+          )}
+        </div>
+      </nav>
+    )
+  }
+
+  NextPrevious.css = style
+
+  return NextPrevious
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -24,6 +24,7 @@ import Comments from "./Comments"
 import Flex from "./Flex"
 import ConditionalRender from "./ConditionalRender"
 import PageColor from "./PageColor"
+import NextPrevious from "./NextPrevious"
 
 export {
   ArticleTitle,
@@ -52,4 +53,5 @@ export {
   Flex,
   ConditionalRender,
   PageColor,
+  NextPrevious,
 }

--- a/quartz/components/styles/nextprevious.scss
+++ b/quartz/components/styles/nextprevious.scss
@@ -1,0 +1,110 @@
+.nextprevious-container {
+  margin: 2rem 0;
+  padding-top: 2rem;
+  border-top: 1px solid var(--lightgray);
+
+  .nextprevious-wrapper {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: stretch;
+
+    a {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 1rem;
+      border-radius: 8px;
+      background-color: var(--light);
+      border: 1px solid var(--lightgray);
+      text-decoration: none;
+      transition: all 0.2s ease;
+      flex: 1;
+      max-width: 48%;
+
+      &:hover {
+        background-color: var(--lightgray);
+        border-color: var(--secondary);
+        transform: translateY(-2px);
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+      }
+
+      .arrow {
+        font-size: 1.5rem;
+        color: var(--secondary);
+        flex-shrink: 0;
+      }
+
+      .link-content {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        min-width: 0;
+
+        .label {
+          font-size: 0.85rem;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: var(--gray);
+          font-weight: 500;
+        }
+
+        .page-title {
+          font-size: 1rem;
+          color: var(--darkgray);
+          font-weight: 600;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+
+      &.previous {
+        .link-content {
+          align-items: flex-start;
+          text-align: left;
+        }
+      }
+
+      &.next {
+        flex-direction: row-reverse;
+
+        .link-content {
+          align-items: flex-end;
+          text-align: right;
+        }
+      }
+    }
+
+    .spacer {
+      flex: 1;
+      max-width: 48%;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .nextprevious-container {
+    .nextprevious-wrapper {
+      flex-direction: column;
+
+      a {
+        max-width: 100%;
+
+        &.previous,
+        &.next {
+          flex-direction: row;
+
+          .link-content {
+            align-items: flex-start;
+            text-align: left;
+          }
+        }
+      }
+
+      .spacer {
+        display: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implemented a new NextPrevious component that displays navigation links between sibling pages within folders. The component:
- Shows previous and next page links with arrows and titles
- Filters to only show in the Cards folder and its subfolders
- Sorts pages alphabetically by title
- Uses responsive design with desktop/mobile layouts
- Styled to match the existing site theme
- Positioned after content, before comments section

Files added:
- quartz/components/NextPrevious.tsx - Main component logic
- quartz/components/styles/nextprevious.scss - Styling

Files modified:
- quartz/components/index.ts - Export new component
- quartz.layout.ts - Add component to page layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Previous/Next page navigation to enhance your browsing experience. A new navigation component appears between page content and comments, allowing quick jumps to adjacent pages within your folder structure. Features responsive design for seamless mobile viewing, customizable folder rules, and conditional display that hides when no adjacent pages exist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->